### PR TITLE
Multiply number of trees found on given slopes

### DIFF
--- a/src/days_of_advent/day03.rs
+++ b/src/days_of_advent/day03.rs
@@ -7,23 +7,34 @@ pub fn run() -> () {
     }
     let puzzle_input = puzzle_input.unwrap();
 
-    let num_trees = count_trees(&puzzle_input);
-    let content = format!("Found {} trees in our path", num_trees);
+    let slopes = [
+        (1,1),
+        (1,3),
+        (1,5),
+        (1,7),
+        (2,1)
+    ];
+
+    let num_trees = count_trees(&puzzle_input, &(1,3));
+
+    let mult_trees : usize = slopes.iter().map(|s| count_trees(&puzzle_input, s)).product();
+    let content = format!("\
+        Found {} trees in our path for slope (1.3)\n\
+        For each slope, multiplied trees were {}", num_trees, mult_trees);
 
     let report = io::format_day_report(3, "Toboggan Trajectory", "Count the trees on the slopes", &content);
     println!("{}", report);
 }
 
-fn count_trees(slopes: &str) -> usize {
+fn count_trees(map: &str, slope: &(usize, usize)) -> usize {
     let mut pos : (usize, usize) = (0, 0);
-    let offset : (usize, usize) = (1, 3);
 
-    let num_columns = slopes.lines().next().unwrap().chars().count();
+    let num_columns = map.lines().next().unwrap().chars().count();
     let mut num_trees : usize = 0;
 
-    while pos.0 < slopes.lines().count() {
-        num_trees += if get_char_at_index(&slopes, pos).unwrap() == '#' {1} else {0};
-        pos = get_index_with_wraparound(pos, offset, num_columns);
+    while pos.0 < map.lines().count() {
+        num_trees += if get_char_at_index(&map, pos).unwrap() == '#' {1} else {0};
+        pos = get_index_with_wraparound(&pos, &slope, num_columns);
     }
 
     num_trees
@@ -40,7 +51,7 @@ fn get_char_at_index(slopes: &str, pos: (usize, usize)) -> Result<char, &str> {
     }
 }
 
-fn get_index_with_wraparound(pos: (usize, usize), offset: (usize, usize), col_limit: usize) -> (usize, usize) {
+fn get_index_with_wraparound(pos: &(usize, usize), offset: &(usize, usize), col_limit: usize) -> (usize, usize) {
     let mut column = pos.1 + offset.1;
     if column > (col_limit - 1) {
         column -= col_limit;
@@ -53,7 +64,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn provided_acceptance_test() {
+    fn provided_acceptance_test_3_1() {
         let input = "\
         ..##.......\n\
         #...#...#..\n\
@@ -68,31 +79,31 @@ mod tests {
         .#..#...#.#\
         ";
 
-        let num_trees = count_trees(&input);
+        let num_trees = count_trees(&input, &(1,3));
         assert_eq!(num_trees, 7);
     }
 
     #[test]
     fn test_grid_slope_1() {
-        let new_position = get_index_with_wraparound((0,0), (0,0), 1);
+        let new_position = get_index_with_wraparound(&(0,0), &(0,0), 1);
         assert_eq!(new_position, (0,0));
     }
 
     #[test]
     fn test_grid_slope_2() {
-        let new_position = get_index_with_wraparound((0,0), (0,1), 2);
+        let new_position = get_index_with_wraparound(&(0,0), &(0,1), 2);
         assert_eq!(new_position, (0,1));
     }
 
     #[test]
     fn test_grid_slope_3() {
-        let new_position = get_index_with_wraparound((0,0), (0,2), 2);
+        let new_position = get_index_with_wraparound(&(0,0), &(0,2), 2);
         assert_eq!(new_position, (0,0));
     }
 
     #[test]
     fn test_grid_slope_4() {
-        let new_position = get_index_with_wraparound((0,0), (1,3), 4);
+        let new_position = get_index_with_wraparound(&(0,0), &(1,3), 4);
         assert_eq!(new_position, (1,3));
     }
 


### PR DESCRIPTION
Removes hardcoded (1,3) slope from count_trees and adds param
Counts trees for provided slopes, and multiplies the result, reporting
it
Fix tests to use new param for count_trees